### PR TITLE
Fix Docker build context and clean docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
-<<<<<<< HEAD
 # EmailGod
-Magic Task Creator
-=======
-# Intelligent Task Creation (ITC) — MVP
 
-Cloud-first task creation system for Peninsulators.
+Magic Task Creator — an intelligent task creation system for Peninsulators.
+
 - Source of Truth: Postgres
 - Task UI: Trello (synced)
 - ChatOps: Zoom Team Chat (slash commands)
@@ -13,19 +10,21 @@ Cloud-first task creation system for Peninsulators.
 
 ## Quick Start (Dev)
 
-1) Copy `.env.example` to `.env` and fill secrets.
-2) `docker compose up -d --build`
-3) Initialize DB and seed: `docker compose exec api python -m app.scripts.dev_seed`
-4) Hit health: http://localhost:8080/health
-5) Try example: `POST /ingest/email` with `examples/ingest_email.json`
+1. Copy `.env.example` to `.env` and fill in secrets.
+2. Run `docker compose up -d --build`.
+3. Initialize and seed the database: `docker compose exec api python -m app.scripts.dev_seed`.
+4. Hit the health check: http://localhost:8080/health.
+5. Try the example request: `POST /ingest/email` with the payload in `examples/ingest_email.json`.
 
 ## Services
-- api: FastAPI + SQLAlchemy
-- worker: background queue (RQ) for heavy jobs (plan indexing)
-- db: Postgres
-- redis: queues & caching
+
+- **api**: FastAPI + SQLAlchemy
+- **worker**: background queue (RQ) for heavy jobs (plan indexing)
+- **db**: Postgres
+- **redis**: queues & caching
 
 ## Repo Layout
+
 ```
 backend/app
   ├─ routers/        # HTTP endpoints
@@ -43,4 +42,3 @@ config/
 n8n/
   └─ README.md
 ```
->>>>>>> 4a68e49 (Initial commit)

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,9 +6,9 @@ ENV PYTHONUNBUFFERED=1
 
 RUN apt-get update && apt-get install -y build-essential libpq-dev && rm -rf /var/lib/apt/lists/*
 
-COPY backend/requirements.txt /app/requirements.txt
+COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r /app/requirements.txt
 
-COPY backend /app
+COPY . /app
 EXPOSE 8080
 CMD ["uvicorn","app.main:app","--host","0.0.0.0","--port","8080"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   db:
     image: postgres:16-alpine


### PR DESCRIPTION
## Summary
- correct the backend Dockerfile so dependencies and sources are copied from the build context
- drop the obsolete version declaration from docker-compose and clean up the README conflict text
- polish quick start documentation formatting for clarity

## Testing
- python -m compileall backend/app

------
https://chatgpt.com/codex/tasks/task_e_68d0597c8774832b90fe3b3dc1625524